### PR TITLE
Use pino-pretty as synchronous stream instead of worker transport

### DIFF
--- a/bin/build-geonames-sqlite
+++ b/bin/build-geonames-sqlite
@@ -2,6 +2,7 @@
 
 import {buildGeonamesSqlite} from '@hebcal/geo-sqlite';
 import {pino} from 'pino';
+import pretty from 'pino-pretty';
 import minimist from 'minimist';
 
 const argv = minimist(process.argv.slice(2), {
@@ -15,13 +16,14 @@ if (argv.help) {
   process.exit(0);
 }
 
-const logger = pino({
-  level: argv.quiet ? 'warn' : 'info',
-  transport: {
-    target: 'pino-pretty',
-    options: {translateTime: 'SYS:standard', ignore: 'pid,hostname'},
-  },
-});
+// Run pino-pretty synchronously as the destination stream rather than via a
+// worker-thread transport. The worker thread (thread-stream) can keep the
+// process alive indefinitely on some platforms (e.g. GitHub Codespaces); a
+// synchronous stream lets the process exit naturally once the work is done.
+const logger = pino({level: argv.quiet ? 'warn' : 'info'}, pretty({
+  translateTime: 'SYS:standard',
+  ignore: 'pid,hostname',
+}));
 
 const args = argv._;
 if (args.length !== 7) {

--- a/bin/make-test-dbs
+++ b/bin/make-test-dbs
@@ -7,6 +7,7 @@
 
 import {buildGeonamesSqlite, makeZipsSqlite} from '@hebcal/geo-sqlite';
 import {pino} from 'pino';
+import pretty from 'pino-pretty';
 import {statSync} from 'fs';
 import path from 'path';
 
@@ -15,13 +16,14 @@ const repoDir = path.join(outDir, 'node_modules/@hebcal/geo-sqlite');
 
 const population = process.env.POPULATION ? +process.env.POPULATION : 0;
 
-const logger = pino({
-  level: 'info',
-  transport: {
-    target: 'pino-pretty',
-    options: {translateTime: 'SYS:standard', ignore: 'pid,hostname'},
-  },
-});
+// Run pino-pretty synchronously as the destination stream rather than via a
+// worker-thread transport. The worker thread (thread-stream) can keep the
+// process alive indefinitely on some platforms (e.g. GitHub Codespaces); a
+// synchronous stream lets the process exit naturally once the work is done.
+const logger = pino({level: 'info'}, pretty({
+  translateTime: 'SYS:standard',
+  ignore: 'pid,hostname',
+}));
 
 const geonamesDb = path.join(outDir, 'geonames.sqlite3');
 const zipsDb = path.join(outDir, 'zips.sqlite3');


### PR DESCRIPTION
## Summary
Refactored logger configuration in build scripts to use `pino-pretty` as a synchronous destination stream instead of a worker-thread transport. This resolves issues where the process could hang indefinitely on certain platforms.

## Changes
- Updated `bin/build-geonames-sqlite` and `bin/make-test-dbs` to import `pino-pretty` directly
- Changed logger initialization from using `pino` with a `transport` configuration to passing `pino-pretty` as a synchronous destination stream
- Maintained all existing logging options (`translateTime: 'SYS:standard'` and `ignore: 'pid,hostname'`)

## Implementation Details
The worker-thread transport (via `thread-stream`) can keep the process alive indefinitely on some platforms like GitHub Codespaces. By using `pino-pretty` as a synchronous stream, the process can now exit naturally once the work is complete, while maintaining the same formatted output and logging behavior.

https://claude.ai/code/session_014DMPxtiShJrUwhx49SP5zF