### PR TITLE
Open geo databases in read-only mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hebcal/geo-sqlite",
-  "version": "5.11.1",
+  "version": "5.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hebcal/geo-sqlite",
-      "version": "5.11.1",
+      "version": "5.12.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@hebcal/cities": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hebcal/geo-sqlite",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hebcal/geo-sqlite",
-      "version": "5.11.0",
+      "version": "5.11.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@hebcal/cities": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hebcal/geo-sqlite",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "author": "Michael J. Radwin (https://github.com/mjradwin)",
   "keywords": [
     "hebcal"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hebcal/geo-sqlite",
-  "version": "5.11.1",
+  "version": "5.12.0",
   "author": "Michael J. Radwin (https://github.com/mjradwin)",
   "keywords": [
     "hebcal"

--- a/src/geodb.ts
+++ b/src/geodb.ts
@@ -168,12 +168,12 @@ export class GeoDb {
     if (!existsSync(zipsFilename)) {
       throw new Error(`GeoDb: ${zipsFilename} does not exist`);
     }
-    this.zipsDb = new DatabaseSync(zipsFilename);
+    this.zipsDb = new DatabaseSync(zipsFilename, {readOnly: true});
     if (logger) logger.info(`GeoDb: opening ${geonamesFilename}...`);
     if (!existsSync(geonamesFilename)) {
       throw new Error(`GeoDb: ${geonamesFilename} does not exist`);
     }
-    this.geonamesDb = new DatabaseSync(geonamesFilename);
+    this.geonamesDb = new DatabaseSync(geonamesFilename, {readOnly: true});
     this.zipStmt = this.zipsDb.prepare(ZIPCODE_SQL);
     const zipsCacheSize = options?.zipsCacheSize || 150;
     this.zipCache = new QuickLRU<string, Location | null>({


### PR DESCRIPTION
Pass {readOnly: true} to the DatabaseSync constructors so clients
cannot write updates to the pre-built ZIP and geonames db files.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VXDVWsVBzXxf2Y8JgioBGw